### PR TITLE
Unverified patch to resolve conflicting requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ datasets==2.18.0
 diffusers==0.27.2
 jieba==0.42.1
 lmdeploy==0.5.3
-numpy==2.1.1
+numpy==1.26.4
 pandas==2.2.2
 Pillow==10.4.0
 pytest==8.1.1
@@ -13,7 +13,7 @@ sacrebleu==2.4.2
 scikit_learn==1.5.1
 sentence_transformers==3.0.1
 setuptools==68.2.2
-torch==2.3.1
+torch==2.3.0
 tqdm==4.66.2
 transformers==4.41.2
 vllm==0.5.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bert_score==0.3.13
 datasets==2.18.0
-diffusers==0.27.2
+git+https://github.com/huggingface/diffusers.git
 jieba==0.42.1
 lmdeploy==0.5.3
 numpy==1.26.4

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from setuptools import find_packages, setup
 def read_requirements():
     with open("./requirements.txt") as file:
         requirements = file.read().splitlines()
+        requirements = [r for r in requirements if not "+" in r]
     return requirements
 
 


### PR DESCRIPTION
In the `requirements.txt` file for this repository, `vllm 0.5.0.post1` requires `torch==2.3.0`, but `torch==2.3.1` is explicitly specified:

https://github.com/alipay/YiJian-Community/blob/91930471a38a753857c70a62bc6b6c6f0ad90f39/requirements.txt#L16

Moreover, `lmdeploy==0.5.3` is listed, which depends on `numpy<2.0.0`, causing a conflict with the `numpy==2.1.1` version specified:

https://github.com/alipay/YiJian-Community/blob/91930471a38a753857c70a62bc6b6c6f0ad90f39/requirements.txt#L5-L6

These conflicts will prevent any successful installation.

Although I haven't tested whether all features function as expected with the updated requirements, aligning the `torch` and `numpy` versions should resolve these version conflicts and restore compatibility. This change is necessary to ensure that the package dependencies are consistent and allow the project to be installed and run properly.